### PR TITLE
Fixing run_id generation

### DIFF
--- a/pytorch/pytorch-deeplab_v3_plus/utils/saver.py
+++ b/pytorch/pytorch-deeplab_v3_plus/utils/saver.py
@@ -9,7 +9,7 @@ class Saver(object):
     def __init__(self, args):
         self.args = args
         self.directory = os.path.join('run', args.dataset, args.checkname)
-        self.runs = sorted(glob.glob(os.path.join(self.directory, 'experiment_*')))
+        self.runs = sorted(glob.glob(os.path.join(self.directory, 'experiment_*')), key=lambda x: int(x.split('_')[-1]))
         run_id = int(self.runs[-1].split('_')[-1]) + 1 if self.runs else 0
 
         self.experiment_dir = os.path.join(self.directory, 'experiment_{}'.format(str(run_id)))


### PR DESCRIPTION
run_id was maxing at 10, rewriting in a previously generated directory. If there was an existing run with the id 10, it would sort it as the second element of the lists of the runs, making the new run_id equal to 9 + 1.